### PR TITLE
Actually support multiple configurations

### DIFF
--- a/master.py
+++ b/master.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import copy
 
 # This class represents a single slave, which just stores some
 # configuration information about that slave.
@@ -78,9 +79,11 @@ class Target:
         return self._branch
 
     def steps(self):
-        mapped_steps = self._steps
-        for step in mapped_steps :
-            step["command"] = map(lambda argv: self.replaceall(argv), step["command"])
+        mapped_steps = []
+        for step in self._steps :
+            mapped_step = copy.deepcopy(step)
+            mapped_step["command"] = map(lambda argv: self.replaceall(argv), step["command"])
+            mapped_steps.append(mapped_step)
         return mapped_steps
 
     def find_matching_slaves(self, slave_list):


### PR DESCRIPTION
This is kind of embarassing: since this code changed to support warnings
went in we haven't actually been elaborating our configurations
correctly.  As a result, only one configuration of each step was being
run for each project.

This changes the step mapping code to perform a deep copy, which causes
each target to get a different set of steps.

This has been broken since September.

Fixes: 8edae36 ("Define steps with a dict to configure ShellCommand,
enable warnings")
